### PR TITLE
[ci] changed base image from alpine to debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,22 @@ In course of mobile app development, a developer receives an asset file from the
 
 Initially, only Android is supported. iOS support is planned.
 
-# Dockerfile
+# Docker
 
 The Dockerfile is used to build the container image that can be used to run the asset transformer. At the moment `deploy/ci/Dockerfile` is used for CI builds. It has `test` and `build` targets. In future `deploy/cd/Dockerfile` will be used for CD builds. It will have `build` and `publish` targets. Additionally `deploy/prod/Dockerfile` will provide a container image which can be used to transform assets in any container environment.
+
+The CI `Dockerfile` depends on a base image, `Dockerfile.gomagick`, so that it sources cached image during CI builds. This speeds up the build process by approx `30 seconds`, rest will require configuring the build and module cache. The base image is being published manually atm-
+
+```bash
+# build the image locally
+docker build -t gomagick:2.0 -f deploy/ci/Dockerfile.gomagick .
+
+# tag the image
+docker tag a32623302329 kaijuci/gomagick:2.0
+
+# push the image
+docker tag a32623302329 kaijuci/gomagick:2.0
+```
 
 # Plan
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build -t gomagick:2.0 -f deploy/ci/Dockerfile.gomagick .
 docker tag a32623302329 kaijuci/gomagick:2.0
 
 # push the image
-docker tag a32623302329 kaijuci/gomagick:2.0
+docker push kaijuci/gomagick:2.0
 ```
 
 # Plan

--- a/cmd/catalog/root.go
+++ b/cmd/catalog/root.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/kaijuci/assets-transformer/vars"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// Add commands here
+	log.Printf("version: %s\n", vars.Version)
 }
 
 func Execute() {

--- a/deploy/ci/Dockerfile
+++ b/deploy/ci/Dockerfile
@@ -41,4 +41,4 @@ RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
 RUN cat results.out
 
 # echo version - mostly to satisfy kaniko
-CMD ./xfrmr 
+ENTRYPOINT ["/app/xfrmr"]

--- a/deploy/ci/Dockerfile
+++ b/deploy/ci/Dockerfile
@@ -24,7 +24,10 @@ RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
     GOOS=linux \
     GOARCH=amd64 \
     GO111MODULE=on \
-    go build ./...
+    go build \
+    -ldflags "-X github.com/kaijuci/assets-transformer/vars.Version=$(git rev-parse --short HEAD)" \
+    -o xfrmr \
+    cmd/main.go
 
 # test
 RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
@@ -36,3 +39,6 @@ RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
 
 # print report
 RUN cat results.out
+
+# echo version - mostly to satisfy kaniko
+CMD ./xfrmr 

--- a/deploy/ci/Dockerfile
+++ b/deploy/ci/Dockerfile
@@ -1,11 +1,16 @@
-FROM kaijuci/gomagick:1.0 AS base
+FROM kaijuci/gomagick:2.0 AS base
 LABEL org.opencontainers.image.authors="sumeet@kaiju.ci"
+
+# install deps
+RUN apt-get update \
+    && apt-get install -y \
+    tree
 
 WORKDIR /app
 COPY go.mod go.sum ./
 
 # fetch dependencies
-RUN go mod download
+RUN go mod download -x
 
 FROM base AS go-build
 
@@ -22,9 +27,12 @@ RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
     go build ./...
 
 # test
-CMD CGO_CFLAGS_ALLOW='-Xpreprocessor' \
+RUN CGO_CFLAGS_ALLOW='-Xpreprocessor' \
     CGO_ENABLED=1 \
     GOOS=linux \
     GOARCH=amd64 \
     GO111MODULE=on \
-    go test -v -cover ./...
+    go test -v -cover ./... 2>&1 | tee results.out
+
+# print report
+RUN cat results.out

--- a/deploy/ci/Dockerfile.gomagick
+++ b/deploy/ci/Dockerfile.gomagick
@@ -1,17 +1,52 @@
-# pushed manually to https://hub.docker.com/repository/docker/kaijuci/gomagick/general
-FROM golang:1.20.6-alpine AS gomagick
+FROM golang:1.20
 LABEL org.opencontainers.image.authors="sumeet@kaiju.ci"
 
-# https://pkgs.alpinelinux.org/package/edge/community/x86/imagemagick
+# ref: https://github.com/gographics/imagick/blob/master/Dockerfile
 
-# install imagemagick and others
-RUN apk update && apk -U --no-cache add \
-    build-base \
-    tree \
-    imagemagick imagemagick-dev
+# ignore APT warnings about not having a TTY
+ENV DEBIAN_FRONTEND noninteractive
+
+# install deps
+RUN apt-get update \
+    && apt-get install -y \
+        wget build-essential \
+        pkg-config \
+        --no-install-recommends \
+    && apt-get -q -y install \
+        libjpeg-dev \
+        libpng-dev \
+        libtiff-dev \
+        libgif-dev \
+        libx11-dev \
+        fontconfig fontconfig-config libfontconfig1-dev \
+        ghostscript gsfonts gsfonts-x11 \
+        libfreetype6-dev \
+        --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGEMAGICK_PROJECT=ImageMagick
+ARG IMAGEMAGICK_VERSION=7.1.1-14
+ENV IMAGEMAGICK_VERSION=$IMAGEMAGICK_VERSION
+
+# fetch sources and build
+RUN cd && \
+	wget https://github.com/ImageMagick/${IMAGEMAGICK_PROJECT}/archive/${IMAGEMAGICK_VERSION}.tar.gz && \
+	tar xvzf ${IMAGEMAGICK_VERSION}.tar.gz && \
+	cd ImageMagick* && \
+	./configure \
+	    --without-magick-plus-plus \
+	    --without-perl \
+	    --disable-openmp \
+	    --with-gvc=no \
+	    --with-fontconfig=yes \
+	    --with-freetype=yes \
+	    --with-gslib \
+	    --disable-docs && \
+	make -j$(nproc) && make install && \
+	ldconfig /usr/local/lib
 
 # verify imagemagick
 RUN convert --version
 
-# check imagemagick installation
+# verify pkg config
 RUN pkg-config --cflags --libs MagickWand

--- a/vars/vars.go
+++ b/vars/vars.go
@@ -1,0 +1,5 @@
+package vars
+
+var (
+	Version string = "0.0"
+)


### PR DESCRIPTION
`go test -v` wasn't running as there was an issue from `alpine` image around creating directories and test output was squashed as well.

**Fix** changed base image to `debian` and saved test output to text file that is echoed at the end of CI run.

**Kaniko issue** CI task was failing for the multistage `Dockerfile` change, the `kaniko` task was crashing and the fix was to set the caching args -

``` yaml
  - --cache=true
  - --cache-ttl=48h
  - --compressed-caching=false
  - --cache-copy-layers=true
```